### PR TITLE
Fix crash with heads

### DIFF
--- a/Shared/src/main/java/dev/tr7zw/skinlayers/mixin/BlockEntityWithoutLevelRendererMixin.java
+++ b/Shared/src/main/java/dev/tr7zw/skinlayers/mixin/BlockEntityWithoutLevelRendererMixin.java
@@ -6,6 +6,7 @@ import static dev.tr7zw.skinlayers.SkullRendererCache.renderNext;
 
 import java.util.Map;
 
+import net.minecraft.Util;
 import org.apache.commons.lang3.StringUtils;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
@@ -58,7 +59,7 @@ public class BlockEntityWithoutLevelRendererMixin {
                         gameProfile = NbtUtils.readGameProfile(compoundTag.getCompound("SkullOwner"));
                     } else if (compoundTag.contains("SkullOwner", 8)
                             && !StringUtils.isBlank(compoundTag.getString("SkullOwner"))) {
-                        gameProfile = new GameProfile(null, compoundTag.getString("SkullOwner"));
+                        gameProfile = new GameProfile(Util.NIL_UUID, compoundTag.getString("SkullOwner"));
                     }
                 }
                 if (gameProfile != null) {

--- a/Shared/src/main/java/dev/tr7zw/skinlayers/mixin/SkullBlockEntityRendererMixin.java
+++ b/Shared/src/main/java/dev/tr7zw/skinlayers/mixin/SkullBlockEntityRendererMixin.java
@@ -45,6 +45,8 @@ public class SkullBlockEntityRendererMixin {
             lastSkull = (SkullSettings) skullBlockEntity;
             GameProfile gameProfile = skullBlockEntity.getOwnerProfile();
             SkinManager skinManager = Minecraft.getInstance().getSkinManager();
+            if (gameProfile == null)
+                return;
             ResourceLocation textureLocation = skinManager.getInsecureSkin(gameProfile).texture();
             if(textureLocation != lastSkull.getLastTexture()) {
                 lastSkull.setInitialized(false);


### PR DESCRIPTION
Closes #123

GameProfile in 1.20.2 no longer allows passing null UUID to it, so I replaced the null value with `Util.NIL_UUID`.

For `SkullBlockEntityRendererMixin`, I simply added a null check to prevent NPE, looks good and doesn't affect visuals so this probably is OK to go.