### PR TITLE
Mixin Changes + Compatibility With my Mod

### DIFF
--- a/src/main/java/dev/tr7zw/skinlayers/mixin/PlayerRendererMixin.java
+++ b/src/main/java/dev/tr7zw/skinlayers/mixin/PlayerRendererMixin.java
@@ -51,21 +51,14 @@ public abstract class PlayerRendererMixin
     //#endif
     // spotless:on
 
-    private boolean loaded = false;
-
-// Somehow doing this in 1.16.5 is a bit unpredictable, only late adding layer works well. Not sure why
-//    @Inject(method = "<init>*", at = @At("RETURN"))
-//    public void onCreate(CallbackInfo info) {
-//        this.addLayer(new CustomLayerFeatureRenderer(this));
-//    }
+   @Inject(method = "<init>", at = @At("RETURN"))
+   public void onCreate(CallbackInfo info) {
+       this.addLayer(new CustomLayerFeatureRenderer(this));
+   }
 
     @SuppressWarnings("resource")
     @Inject(method = "setModelProperties", at = @At("RETURN"))
     public void setModelProperties(AbstractClientPlayer abstractClientPlayer, CallbackInfo info) {
-        if (!loaded) {
-            this.addLayer(new CustomLayerFeatureRenderer(this));
-            loaded = true;
-        }
         if (Minecraft.getInstance().player == null || Minecraft.getInstance().player
                 .distanceToSqr(abstractClientPlayer) > SkinLayersModBase.config.renderDistanceLOD
                         * SkinLayersModBase.config.renderDistanceLOD) {


### PR DESCRIPTION
# Reason for Change

As expressed in a Discord thread, this mod, for some reason, would cause rendering issues for one of my mods which adds a feature renderer.  The solution to the problem, as documented [here](https://discord.com/channels/342814924310970398/1237151107176992798/1237928349003939870) and tested on the `1.20` branch, shows that injecting into the `PlayerRenderer` constructor with the annotation of 

```java
@Inject(method = "<init>*", at = @At("RETURN"))
```

would, for some reason, cause my mod to have rendering issues.  Changing it to 

```java
@Inject(method = "<init>", at = @At("RETURN"))
```

fixes the rendering issues.

# Changes

Because I initially tested this on the `1.20` branch, I was not aware that the `main` branch had a different method for adding the `CustomLayerFeatureRenderer`.  Upon looking at the `PlayerRendererMixin`, the `CustomLayerFeatureRenderer` was adding by injecting into Minecraft's `PlayerRenderer#setModelProperties`.  The change log is as follows:


- Changed how the `CustomLayerFeatureRenderer` was added to the PlayerRenderer. Formally, this was done by injecting into Minecraft's `PlayerRenderer#setModelProperties`, but is now injecting into the constructor.

- There was a concern that "Somehow [injecting into the constructor to add the CustomLayerFeatureRenderer] in 1.16.5 is a bit unpredictable, [and that] only late adding layer works well," but my testing has shown there are no prevailing issues.