### PR TITLE
Minecraft 1.21

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -465,3 +465,41 @@ jobs:
           name: ${{github.ref_name}}-1.21 - Fabric
           files: 'versions/1.21-fabric/build/libs/!(*-@(dev|sources|javadoc|all)).jar'
           game-versions: 1.21
+      - name: Publish-1.21-forge-Curseforge
+        uses: Kir-Antipov/mc-publish@v3.3.0
+        with:
+          curseforge-id: 521480
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          loaders: forge
+          name: ${{github.ref_name}}-1.21 - Forge
+          version-type: beta
+          files: 'versions/1.21-forge/build/libs/!(*-@(dev|sources|javadoc|all)).jar'
+          game-versions: 1.21
+      - name: Publish-1.21-forge-Modrinth
+        uses: Kir-Antipov/mc-publish@v3.3.0
+        with:
+          modrinth-id: zV5r3pPn
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          loaders: forge
+          name: ${{github.ref_name}}-1.21 - Forge
+          files: 'versions/1.21-forge/build/libs/!(*-@(dev|sources|javadoc|all)).jar'
+          game-versions: 1.21
+      - name: Publish-1.21-neoforge-Curseforge
+        uses: Kir-Antipov/mc-publish@v3.3.0
+        with:
+          curseforge-id: 521480
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          loaders: neoforge
+          name: ${{github.ref_name}}-1.21 - NeoForge
+          version-type: beta
+          files: 'versions/1.21-neoforge/build/libs/!(*-@(dev|sources|javadoc|all)).jar'
+          game-versions: 1.21
+      - name: Publish-1.21-neoforge-Modrinth
+        uses: Kir-Antipov/mc-publish@v3.3.0
+        with:
+          modrinth-id: zV5r3pPn
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          loaders: neoforge
+          name: ${{github.ref_name}}-1.21 - NeoForge
+          files: 'versions/1.21-neoforge/build/libs/!(*-@(dev|sources|javadoc|all)).jar'
+          game-versions: 1.21

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -447,3 +447,21 @@ jobs:
           name: ${{github.ref_name}}-1.20.6 - Fabric
           files: 'versions/1.20.6-fabric/build/libs/!(*-@(dev|sources|javadoc|all)).jar'
           game-versions: 1.20.6
+      - name: Publish-1.21-fabric-Curseforge
+        uses: Kir-Antipov/mc-publish@v3.3.0
+        with:
+          curseforge-id: 521480
+          curseforge-token: ${{ secrets.CURSEFORGE_TOKEN }}
+          loaders: fabric
+          name: ${{github.ref_name}}-1.21 - Fabric
+          files: 'versions/1.21-fabric/build/libs/!(*-@(dev|sources|javadoc|all)).jar'
+          game-versions: 1.21
+      - name: Publish-1.21-fabric-Modrinth
+        uses: Kir-Antipov/mc-publish@v3.3.0
+        with:
+          modrinth-id: zV5r3pPn
+          modrinth-token: ${{ secrets.MODRINTH_TOKEN }}
+          loaders: fabric
+          name: ${{github.ref_name}}-1.21 - Fabric
+          files: 'versions/1.21-fabric/build/libs/!(*-@(dev|sources|javadoc|all)).jar'
+          game-versions: 1.21

--- a/settings.json
+++ b/settings.json
@@ -22,6 +22,7 @@
         "1.20.4-fabric",
         "1.20.6-forge",
         "1.20.6-neoforge",
-        "1.20.6-fabric"
+        "1.20.6-fabric",
+        "1.21-fabric"
     ]
 }

--- a/settings.json
+++ b/settings.json
@@ -23,6 +23,8 @@
         "1.20.6-forge",
         "1.20.6-neoforge",
         "1.20.6-fabric",
-        "1.21-fabric"
+        "1.21-fabric",
+        "1.21-forge",
+        "1.21-neoforge"
     ]
 }

--- a/src/main/java/dev/tr7zw/skinlayers/api/Mesh.java
+++ b/src/main/java/dev/tr7zw/skinlayers/api/Mesh.java
@@ -28,7 +28,7 @@ public interface Mesh {
 
         @Override
         public void render(ModelPart vanillaModel, PoseStack poseStack, VertexConsumer vertexConsumer, int light,
-                int overlay, float red, float green, float blue, float alpha) {
+                int overlay, int color) {
         }
 
         @Override
@@ -52,11 +52,14 @@ public interface Mesh {
     };
 
     public default void render(PoseStack poseStack, VertexConsumer vertexConsumer, int light, int overlay) {
-        render(null, poseStack, vertexConsumer, light, overlay, 1.0F, 1.0F, 1.0F, 1.0F);
+        render(null, poseStack, vertexConsumer, light, overlay, 0xFFFFFFFF);
     }
 
+    /**
+     * @param color The color, in ARGB format
+     */
     public void render(ModelPart vanillaModel, PoseStack poseStack, VertexConsumer vertexConsumer, int light,
-            int overlay, float red, float green, float blue, float alpha);
+                       int overlay, int color);
 
     public void setPosition(float x, float y, float z);
 

--- a/src/main/java/dev/tr7zw/skinlayers/config/ConfigScreenProvider.java
+++ b/src/main/java/dev/tr7zw/skinlayers/config/ConfigScreenProvider.java
@@ -28,14 +28,6 @@ public class ConfigScreenProvider {
     public static Screen createConfigScreen(Screen parent) {
         return new CustomConfigScreen(parent, "text.skinlayers.title") {
 
-            // spotless:off
-            //#if MC >= 12100
-            @Override
-            protected void addOptions() {
-            }
-            //#endif
-            //spotless:on
-
             @Override
             public void initialize() {
                 Config config = SkinLayersModBase.config;

--- a/src/main/java/dev/tr7zw/skinlayers/config/ConfigScreenProvider.java
+++ b/src/main/java/dev/tr7zw/skinlayers/config/ConfigScreenProvider.java
@@ -28,9 +28,13 @@ public class ConfigScreenProvider {
     public static Screen createConfigScreen(Screen parent) {
         return new CustomConfigScreen(parent, "text.skinlayers.title") {
 
+            // spotless:off
+            //#if MC >= 12100
             @Override
             protected void addOptions() {
             }
+            //#endif
+            //spotless:on
 
             @Override
             public void initialize() {

--- a/src/main/java/dev/tr7zw/skinlayers/config/ConfigScreenProvider.java
+++ b/src/main/java/dev/tr7zw/skinlayers/config/ConfigScreenProvider.java
@@ -29,6 +29,10 @@ public class ConfigScreenProvider {
         return new CustomConfigScreen(parent, "text.skinlayers.title") {
 
             @Override
+            protected void addOptions() {
+            }
+
+            @Override
             public void initialize() {
                 Config config = SkinLayersModBase.config;
                 List<Object> options = new ArrayList<>();

--- a/src/main/java/dev/tr7zw/skinlayers/render/CustomizableModelPart.java
+++ b/src/main/java/dev/tr7zw/skinlayers/render/CustomizableModelPart.java
@@ -115,7 +115,7 @@ public class CustomizableModelPart extends CustomModelPart implements Mesh {
 
         for (ModelPart modelPart : this.children.values()) {
             // spotless:off
-            //#if MC > 12100
+            //#if MC >= 12100
             modelPart.render(poseStack, vertexConsumer, light, overlay, color);
             //#else
             //$$ modelPart.render(poseStack, vertexConsumer, light, overlay, r, g, b, a);

--- a/src/main/java/dev/tr7zw/skinlayers/render/CustomizableModelPart.java
+++ b/src/main/java/dev/tr7zw/skinlayers/render/CustomizableModelPart.java
@@ -106,9 +106,9 @@ public class CustomizableModelPart extends CustomModelPart implements Mesh {
         // spotless:off
         //#if MC < 12100
         //$$ float r,g,b,a;
-        //$$ a = color >> 24 & 0xFF;
-        //$$ r = color >> 16 & 0xFF;
-        //$$ g = color >> 8 & 0xFF;
+        //$$ a = (color >> 24) & 0xFF;
+        //$$ r = (color >> 16) & 0xFF;
+        //$$ g = (color >> 8) & 0xFF;
         //$$ b = color & 0xFF;
         //#endif
         //spotless:on
@@ -155,9 +155,9 @@ public class CustomizableModelPart extends CustomModelPart implements Mesh {
         // spotless:off
         //#if MC < 12100
         //$$ float red,green,blue,alpha;
-        //$$ alpha = color >> 24 & 0xFF;
-        //$$ red = color >> 16 & 0xFF;
-        //$$ green = color >> 8 & 0xFF;
+        //$$ alpha = (color >> 24) & 0xFF;
+        //$$ red = (color >> 16) & 0xFF;
+        //$$ green = (color >> 8) & 0xFF;
         //$$ blue = color & 0xFF;
         //#endif
         //spotless:on

--- a/src/main/java/dev/tr7zw/skinlayers/render/CustomizableModelPart.java
+++ b/src/main/java/dev/tr7zw/skinlayers/render/CustomizableModelPart.java
@@ -106,10 +106,10 @@ public class CustomizableModelPart extends CustomModelPart implements Mesh {
         // spotless:off
         //#if MC < 12100
         //$$ float r,g,b,a;
-        //$$ a = (color >> 24) & 0xFF;
-        //$$ r = (color >> 16) & 0xFF;
-        //$$ g = (color >> 8) & 0xFF;
-        //$$ b = color & 0xFF;
+        //$$ a = ((color >> 24) & 0xFF) / 255F;
+        //$$ r = ((color >> 16) & 0xFF) / 255F;
+        //$$ g = ((color >> 8) & 0xFF) / 255F;
+        //$$ b = (color & 0xFF) / 255F;
         //#endif
         //spotless:on
 
@@ -155,10 +155,10 @@ public class CustomizableModelPart extends CustomModelPart implements Mesh {
         // spotless:off
         //#if MC < 12100
         //$$ float red,green,blue,alpha;
-        //$$ alpha = (color >> 24) & 0xFF;
-        //$$ red = (color >> 16) & 0xFF;
-        //$$ green = (color >> 8) & 0xFF;
-        //$$ blue = color & 0xFF;
+        //$$ alpha = ((color >> 24) & 0xFF) / 255F;
+        //$$ red = ((color >> 16) & 0xFF) / 255F;
+        //$$ green = ((color >> 8) & 0xFF) / 255F;
+        //$$ blue = (color & 0xFF) / 255F;
         //#endif
         //spotless:on
 

--- a/src/main/java/dev/tr7zw/skinlayers/renderlayers/CustomLayerFeatureRenderer.java
+++ b/src/main/java/dev/tr7zw/skinlayers/renderlayers/CustomLayerFeatureRenderer.java
@@ -137,7 +137,7 @@ public class CustomLayerFeatureRenderer extends RenderLayer<AbstractClientPlayer
 
                 mesh.setPosition(x, y, 0);
 
-                mesh.render(layer.vanillaGetter.get(), matrixStack, vertices, light, overlay, 1.0f, 1.0f, 1.0f, 1.0f);
+                mesh.render(layer.vanillaGetter.get(), matrixStack, vertices, light, overlay, 0xFFFFFFFF);
                 matrixStack.popPose();
             }
         }

--- a/versions/mainProject
+++ b/versions/mainProject
@@ -1,1 +1,1 @@
-1.20.6-fabric
+1.21-fabric


### PR DESCRIPTION
Haven't tested compatibility with older Minecraft versions.

The old `render` method in CustomizableModelPart is kept for compat with mods calling this method (like ETF) so they won't need to update to use (unless they inject their code into this).