### PR TITLE
improve occlusion culling with transparent pixels

### DIFF
--- a/src/main/java/dev/tr7zw/skinlayers/util/NMSWrapper.java
+++ b/src/main/java/dev/tr7zw/skinlayers/util/NMSWrapper.java
@@ -9,6 +9,7 @@ public class NMSWrapper {
 
     public static class WrappedNativeImage implements TextureData {
 
+        private static final int SOLID_THRESHOLD = 230;
         private final NativeImage natImage;
 
         public WrappedNativeImage(NativeImage natImage) {
@@ -17,12 +18,18 @@ public class NMSWrapper {
 
         @Override
         public boolean isPresent(UV onTextureUV) {
-            return natImage.getLuminanceOrAlpha(onTextureUV.u(), onTextureUV.v()) != 0;
+            byte unsignedAlpha = natImage.getLuminanceOrAlpha(onTextureUV.u(), onTextureUV.v());
+            int alpha = unsignedAlpha & 0xFF; // convert to int [0, 255]
+
+            return alpha > (0xFF - SOLID_THRESHOLD);
         }
 
         @Override
         public boolean isSolid(UV onTextureUV) {
-            return natImage.getLuminanceOrAlpha(onTextureUV.u(), onTextureUV.v()) == -1;
+            byte unsignedAlpha = natImage.getLuminanceOrAlpha(onTextureUV.u(), onTextureUV.v());
+            int alpha = unsignedAlpha & 0xFF; // convert to int [0, 255]
+
+            return alpha > SOLID_THRESHOLD;
         }
 
     }


### PR DESCRIPTION
Improves the look of occlusion culling with transparent pixels by considering almost-solid pixels as solid, and almost-invisible pixels as invisible

Before:
<img width="1920" height="1017" alt="Before occlusion culling improvements" src="https://github.com/user-attachments/assets/31338863-957f-47d8-97e7-866082654f38" />

After:
<img width="1920" height="1017" alt="After occlusion culling improvements" src="https://github.com/user-attachments/assets/4911d4f1-5923-496e-8e74-cc0fb4cf337e" />
